### PR TITLE
feat: add rootless Podman support for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,13 @@
           "default": 443,
           "scope": "KubernetesProviderConnectionFactory",
           "description": "HTTPS Port for the routes"
+        },
+        "microshift.cluster.creation.allow.rootless": {
+          "type": "boolean",
+          "default": false,
+          "scope": "KubernetesProviderConnectionFactory",
+          "description": "Allow rootless Podman (Linux only). Requires host prerequisites (cpuset delegation and subordinate UID/GID ranges).",
+          "when": "isLinux"
         }
       }
     }

--- a/src/helper/create-cluster-helper.spec.ts
+++ b/src/helper/create-cluster-helper.spec.ts
@@ -77,6 +77,34 @@ describe('create', () => {
     );
   });
 
+  test('should pass --allow-rootless flag when rootless mode is enabled', async () => {
+    await createClusterHelper.create('/path/to/minc', {
+      'microshift.cluster.creation.allow.rootless': true,
+    });
+    expect(podmanDesktopProcess.exec).toHaveBeenCalledWith(
+      '/path/to/minc',
+      ['create', '--http-port', '80', '--https-port', '443', '--allow-rootless'],
+      {
+        logger: undefined,
+        token: undefined,
+      },
+    );
+  });
+
+  test('should not pass --allow-rootless flag when rootless mode is disabled', async () => {
+    await createClusterHelper.create('/path/to/minc', {
+      'microshift.cluster.creation.allow.rootless': false,
+    });
+    expect(podmanDesktopProcess.exec).toHaveBeenCalledWith(
+      '/path/to/minc',
+      ['create', '--http-port', '80', '--https-port', '443'],
+      {
+        logger: undefined,
+        token: undefined,
+      },
+    );
+  });
+
   test('should throw an error if the create command fails', async () => {
     vi.mocked(podmanDesktopProcess.exec).mockRejectedValue(new Error('Execution failed'));
 

--- a/src/helper/create-cluster-helper.ts
+++ b/src/helper/create-cluster-helper.ts
@@ -52,17 +52,21 @@ export class CreateClusterHelper {
       httpsHostPort = Number(params['microshift.cluster.creation.https.port']);
     }
 
+    // check if rootless mode is requested
+    const allowRootless = params['microshift.cluster.creation.allow.rootless'] === true;
+
+    const args = ['create', '--http-port', String(httpHostPort), '--https-port', String(httpsHostPort)];
+    if (allowRootless) {
+      args.push('--allow-rootless');
+    }
+
     // now execute the command to create the cluster
     const startTime = performance.now();
     try {
-      await process.exec(
-        mincCliPath,
-        ['create', '--http-port', String(httpHostPort), '--https-port', String(httpsHostPort)],
-        {
-          logger,
-          token,
-        },
-      );
+      await process.exec(mincCliPath, args, {
+        logger,
+        token,
+      });
     } catch (error: unknown) {
       telemetryOptions.error = error;
       let errorMessage = '';

--- a/src/manager/provider-manager.spec.ts
+++ b/src/manager/provider-manager.spec.ts
@@ -365,15 +365,16 @@ describe('auditRecords', () => {
     expect(result.records).toEqual([]);
   });
 
-  test('should return warning on Linux if running as non-root', async () => {
+  test('should return info on Linux if running as non-root', async () => {
     vi.mocked(env).isLinux = true;
     vi.mocked(podmanDesktopProcess.exec).mockResolvedValue({ stdout: '1000' } as RunResult);
 
     const result = await providerManager.auditRecords();
     expect(result.records).toEqual([
       {
-        type: 'error',
-        record: 'MINC requires a rootful podman. It is not possible to create a minc cluster in rootless mode.',
+        type: 'info',
+        record:
+          'Running as non-root user. The cluster will be created in rootless mode (--allow-rootless). Ensure host prerequisites are configured (cpuset delegation, subordinate UID/GID ranges).',
       },
     ]);
   });

--- a/src/manager/provider-manager.spec.ts
+++ b/src/manager/provider-manager.spec.ts
@@ -374,7 +374,7 @@ describe('auditRecords', () => {
       {
         type: 'info',
         record:
-          'Running as non-root user. The cluster will be created in rootless mode (--allow-rootless). Ensure host prerequisites are configured (cpuset delegation, subordinate UID/GID ranges).',
+          'Running as non-root user. To create in rootless mode, enable "Allow rootless Podman" (--allow-rootless). Ensure host prerequisites are configured (cpuset delegation, subordinate UID/GID ranges).',
       },
     ]);
   });

--- a/src/manager/provider-manager.ts
+++ b/src/manager/provider-manager.ts
@@ -142,8 +142,9 @@ export class ProviderManager {
       const uid = idCommandResult.stdout.trim();
       if (uid !== '0') {
         records.push({
-          type: 'error',
-          record: 'MINC requires a rootful podman. It is not possible to create a minc cluster in rootless mode.',
+          type: 'info',
+          record:
+            'Running as non-root user. The cluster will be created in rootless mode (--allow-rootless). Ensure host prerequisites are configured (cpuset delegation, subordinate UID/GID ranges).',
         });
       }
       return { records };

--- a/src/manager/provider-manager.ts
+++ b/src/manager/provider-manager.ts
@@ -144,7 +144,7 @@ export class ProviderManager {
         records.push({
           type: 'info',
           record:
-            'Running as non-root user. The cluster will be created in rootless mode (--allow-rootless). Ensure host prerequisites are configured (cpuset delegation, subordinate UID/GID ranges).',
+            'Running as non-root user. To create in rootless mode, enable "Allow rootless Podman" (--allow-rootless). Ensure host prerequisites are configured (cpuset delegation, subordinate UID/GID ranges).',
         });
       }
       return { records };


### PR DESCRIPTION
## Summary

- Add an **"Allow rootless Podman"** toggle to the cluster creation form (`package.json` configuration, Linux only)
- Pass `--allow-rootless` flag to `minc create` when the toggle is enabled
- Change the Linux audit from a **blocking error** to an **informational message** when running as non-root user, since rootless mode is now a supported configuration

## Dependencies

This PR depends on [minc-org/minc#68](https://github.com/minc-org/minc/pull/68) which adds the `--allow-rootless` flag to the minc CLI.

## Changes

| File | Change |
|------|--------|
| `package.json` | New `microshift.cluster.creation.allow.rootless` boolean field (default `false`, visible on Linux only) |
| `src/helper/create-cluster-helper.ts` | Read the new parameter and append `--allow-rootless` to the CLI args when enabled |
| `src/manager/provider-manager.ts` | Linux audit changed from `error` to `info` when UID ≠ 0 |
| `src/helper/create-cluster-helper.spec.ts` | Two new tests for the `--allow-rootless` flag (enabled/disabled) |
| `src/manager/provider-manager.spec.ts` | Updated audit expectation from `error` to `info` for non-root Linux |

## Evidence

### 1. Cluster creation form with rootless toggle and info banner
<img width="1353" height="351" alt="Screenshot From 2026-04-15 14-24-19" src="https://github.com/user-attachments/assets/e83b3a7f-09cc-48a5-b6ba-99ac0c4ed1a5" />



### 2. Cluster creation in progress (rootless, logs visible)
<img width="1172" height="584" alt="Screenshot From 2026-04-15 14-00-25" src="https://github.com/user-attachments/assets/03db5567-ac79-4920-a828-cdfbd0c2119f" />


### 3. Rootless container running (`podman ps` + `minc status`)
<img width="1347" height="275" alt="Screenshot From 2026-04-15 14-01-16" src="https://github.com/user-attachments/assets/d728425d-1b83-4f89-a455-03226670520d" />


### 4. MicroShift provider running in Podman Desktop Resources
<img width="746" height="172" alt="Screenshot From 2026-04-15 14-01-53" src="https://github.com/user-attachments/assets/26808d88-9854-41eb-92d4-5fb1720b3eaa" />


### 5. Kubernetes engine details (endpoint https://localhost:6443)
<img width="209" height="170" alt="Screenshot From 2026-04-15 14-02-13" src="https://github.com/user-attachments/assets/4c745e1a-203f-4339-ab60-0c52464795fb" />


### 6. All system pods running (`oc get node` + `oc get pod -A`)
<img width="1343" height="578" alt="Screenshot From 2026-04-15 14-02-45" src="https://github.com/user-attachments/assets/b41fd8f4-0ac1-465a-ae2b-c2fa37e73854" />


## Test plan

- [x] All 126 unit tests passing with 100% coverage
- [x] TypeScript typecheck clean
- [x] Manual test: rootless cluster created successfully via Podman Desktop on Fedora 43
- [x] Manual test: all MicroShift system pods reach Running status
- [ ] Verify checkbox does not appear on macOS/Windows (expected due to `"when": "isLinux"`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to allow rootless Podman for MicroShift cluster creation on Linux (disabled by default).

* **Improvements**
  * Audit messaging for non-root Linux now offers guidance and required host prerequisites (cpuset delegation and subordinate UID/GID ranges) and suggests using the rootless option instead of reporting it as unsupported.

* **Tests**
  * Added unit tests verifying the rootless option toggles the cluster creation command accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->